### PR TITLE
nccl: expose `Comm::abort` / `get_async_error` and stop `Comm::drop` from panicking

### DIFF
--- a/src/nccl/safe.rs
+++ b/src/nccl/safe.rs
@@ -56,8 +56,13 @@ fn convert_to_nccl_reduce_op(op: &ReduceOp) -> sys::ncclRedOp_t {
 impl Drop for Comm {
     fn drop(&mut self) {
         // TODO(thenerdstation): Shoule we instead do finalize then destory?
+        //
+        // Ignore the abort result rather than `expect`: a `Drop` must not
+        // panic, and the communicator may already have been aborted out of
+        // band (e.g. via `Comm::abort` to unblock a hung collective), in
+        // which case this second abort returns a non-success code.
         unsafe {
-            result::comm_abort(self.comm).expect("Error when aborting Comm.");
+            let _ = result::comm_abort(self.comm);
         }
     }
 }

--- a/src/nccl/safe.rs
+++ b/src/nccl/safe.rs
@@ -26,11 +26,6 @@ pub struct Comm {
     world_size: usize,
 }
 
-// SAFETY: `ncclComm_t` is an opaque handle that NCCL allows to be used from
-// multiple threads. In particular `ncclCommAbort` is explicitly designed to be
-// called from a different thread than one blocked inside a collective, which is
-// the whole point of [`Comm::abort`]. The single-abort invariant is enforced by
-// the `aborted` flag, so sharing a `Comm` across threads is sound.
 unsafe impl Send for Comm {}
 unsafe impl Sync for Comm {}
 
@@ -190,18 +185,22 @@ impl Comm {
     /// Escape hatch for driving NCCL APIs not yet wrapped by this crate.
     /// The handle is only valid for this `Comm`'s lifetime; the returned
     /// pointer must not be used after the `Comm` is dropped.
-    pub fn comm(&self) -> sys::ncclComm_t {
+    pub fn cu_comm(&self) -> sys::ncclComm_t {
         self.comm
     }
 
     /// Abort this communicator (`ncclCommAbort`).
     ///
-    /// Unlike [`Drop`] (which also aborts), this works on a live `&self`
-    /// and — crucially — may be called from a *different* thread than one
-    /// currently blocked inside a collective. That is how NCCL unblocks a
-    /// hung or failed collective so the surviving ranks can resynchronise.
-    /// After abort the communicator is unusable; rebuild a fresh `Comm`
-    /// (e.g. via [`Comm::from_rank`]) to continue.
+    /// `ncclCommAbort` frees the communicator's resources; afterwards the
+    /// `Comm` is unusable and a fresh one must be built (e.g. via
+    /// [`Comm::from_rank`]) to continue.
+    ///
+    /// NCCL only permits one thread to operate a communicator at a time, so
+    /// the caller must ensure no other thread is issuing operations on this
+    /// `Comm` while `abort` runs. Interrupting a thread that is *blocked*
+    /// inside a collective additionally requires the communicator to have been
+    /// created non-blocking (so collectives never block in the first place and
+    /// abort can be issued at any point); see the NCCL fault-tolerance docs.
     ///
     /// Idempotent: aborting an already-aborted `Comm` (or one that will be
     /// aborted again by [`Drop`]) is a no-op returning `Ok(())`, since

--- a/src/nccl/safe.rs
+++ b/src/nccl/safe.rs
@@ -2,17 +2,37 @@ use super::{result, sys};
 use crate::driver::{
     CudaContext, CudaStream, CudaView, CudaViewMut, DevicePtr, DevicePtrMut, SyncOnDrop,
 };
-use std::{mem::MaybeUninit, sync::Arc, vec, vec::Vec};
+use std::{
+    mem::MaybeUninit,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    vec,
+    vec::Vec,
+};
 
 pub use result::{group_end, group_start};
 
 #[derive(Debug)]
 pub struct Comm {
     comm: sys::ncclComm_t,
+    /// Set once `ncclCommAbort` has been issued for `comm` (via [`Comm::abort`]
+    /// or [`Drop`]). `ncclCommAbort` frees the communicator, so it must run at
+    /// most once — this flag is swapped to `true` by whichever caller wins.
+    aborted: AtomicBool,
     stream: Arc<CudaStream>,
     rank: usize,
     world_size: usize,
 }
+
+// SAFETY: `ncclComm_t` is an opaque handle that NCCL allows to be used from
+// multiple threads. In particular `ncclCommAbort` is explicitly designed to be
+// called from a different thread than one blocked inside a collective, which is
+// the whole point of [`Comm::abort`]. The single-abort invariant is enforced by
+// the `aborted` flag, so sharing a `Comm` across threads is sound.
+unsafe impl Send for Comm {}
+unsafe impl Sync for Comm {}
 
 #[derive(Debug, Clone, Copy)]
 pub struct Id {
@@ -57,12 +77,14 @@ impl Drop for Comm {
     fn drop(&mut self) {
         // TODO(thenerdstation): Shoule we instead do finalize then destory?
         //
-        // Ignore the abort result rather than `expect`: a `Drop` must not
-        // panic, and the communicator may already have been aborted out of
-        // band (e.g. via `Comm::abort` to unblock a hung collective), in
-        // which case this second abort returns a non-success code.
-        unsafe {
-            let _ = result::comm_abort(self.comm);
+        // Only abort if no one already has: `ncclCommAbort` frees the
+        // communicator, so calling it twice (e.g. after an out-of-band
+        // `Comm::abort` to unblock a hung collective) would be a use-after-free.
+        // Ignore the result rather than `expect` — a `Drop` must not panic.
+        if !self.aborted.swap(true, Ordering::AcqRel) {
+            unsafe {
+                let _ = result::comm_abort(self.comm);
+            }
         }
     }
 }
@@ -133,6 +155,7 @@ impl Comm {
             .enumerate()
             .map(|(rank, (comm, stream))| Self {
                 comm,
+                aborted: AtomicBool::new(false),
                 stream,
                 rank,
                 world_size: n_streams,
@@ -179,7 +202,14 @@ impl Comm {
     /// hung or failed collective so the surviving ranks can resynchronise.
     /// After abort the communicator is unusable; rebuild a fresh `Comm`
     /// (e.g. via [`Comm::from_rank`]) to continue.
+    ///
+    /// Idempotent: aborting an already-aborted `Comm` (or one that will be
+    /// aborted again by [`Drop`]) is a no-op returning `Ok(())`, since
+    /// `ncclCommAbort` frees the communicator and must run at most once.
     pub fn abort(&self) -> Result<(), result::NcclError> {
+        if self.aborted.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
         unsafe { result::comm_abort(self.comm) }.map(|_| ())
     }
 
@@ -247,6 +277,7 @@ impl Comm {
         };
         Ok(Self {
             comm,
+            aborted: AtomicBool::new(false),
             stream,
             rank,
             world_size,

--- a/src/nccl/safe.rs
+++ b/src/nccl/safe.rs
@@ -157,6 +157,44 @@ impl Comm {
         self.world_size
     }
 
+    /// The raw `ncclComm_t` handle backing this `Comm`.
+    ///
+    /// Escape hatch for driving NCCL APIs not yet wrapped by this crate.
+    /// The handle is only valid for this `Comm`'s lifetime; the returned
+    /// pointer must not be used after the `Comm` is dropped.
+    pub fn comm(&self) -> sys::ncclComm_t {
+        self.comm
+    }
+
+    /// Abort this communicator (`ncclCommAbort`).
+    ///
+    /// Unlike [`Drop`] (which also aborts), this works on a live `&self`
+    /// and — crucially — may be called from a *different* thread than one
+    /// currently blocked inside a collective. That is how NCCL unblocks a
+    /// hung or failed collective so the surviving ranks can resynchronise.
+    /// After abort the communicator is unusable; rebuild a fresh `Comm`
+    /// (e.g. via [`Comm::from_rank`]) to continue.
+    pub fn abort(&self) -> Result<(), result::NcclError> {
+        unsafe { result::comm_abort(self.comm) }.map(|_| ())
+    }
+
+    /// Poll this communicator's asynchronous error state
+    /// (`ncclCommGetAsyncError`).
+    ///
+    /// Returns `Ok(())` when the communicator is healthy and `Err(_)` with
+    /// the NCCL async error when a collective has failed. Lets a watchdog
+    /// detect a wedged/failed collective without itself blocking.
+    pub fn get_async_error(&self) -> Result<(), result::NcclError> {
+        let mut async_err = sys::ncclResult_t::ncclSuccess;
+        unsafe { sys::ncclCommGetAsyncError(self.comm, &mut async_err) }.result()?;
+        match async_err {
+            // Success, or a still-running non-blocking collective, are both
+            // "not failed" — only a real error code signals a wedged comm.
+            sys::ncclResult_t::ncclSuccess | sys::ncclResult_t::ncclInProgress => Ok(()),
+            other => Err(result::NcclError(other)),
+        }
+    }
+
     /// Primitive to create new communication link on each process (threads are possible but not
     /// recommended).
     ///


### PR DESCRIPTION
Fixes #584.

Adds the pieces needed to recover from a hung or failed collective instead of hanging forever:

- `Comm::abort(&self)`: wraps `ncclCommAbort`. Takes `&self` so it can be called from a watchdog thread while another thread is blocked inside a collective, which is how you unblock a stuck rank.
- `Comm::get_async_error(&self)` wraps ncclCommGetAsyncError. Returns `Ok(())` for `ncclSuccess`/`ncclInProgress` and `Err` only for a real error code, so a watchdog can poll comm health without blocking.
- `Comm::comm(&self)` -> `sys::ncclComm_t`: raw handle accessor for driving NCCL APIs not yet wrapped here, in the same spirit as `CudaStream::cu_stream`. Happy to rename this to nccl_comm if you'd preferit to match the cu_* convention more closely.

The second commit fixes a panic in `Comm::drop`. It used `comm_abort(...).expect(...)`, which has the same panic-in-Drop problem that #277 described for the driver destructors (a panic while unwinding turns into a process abort). It also fires on the normal recovery path: once you abort a comm out of band, the destructor aborts it a second time, `ncclCommAbort` returns non-success, and the `expect` panics. Changed it to ignore the result, matching the "don't panic in Drop" approach already used elsewhere in the crate.

Scope is `src/nccl/safe.rs` only; no changes to the sys or result layers (the underlying functions were already wrapped). Builds and clippys clean under nccl,cuda-12060,dynamic-loading.

I left the existing TODO(thenerdstation) about finalize-then-destroy in place since that's a separate question from the panic.