### PR TITLE
Fix: gate CudaSlice/SyncOnDrop teardown behind is_managing_stream_synchronization

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -2470,11 +2470,13 @@ impl<T> CudaSlice<T> {
         let ptr = s.cu_device_ptr;
 
         // Ensure pending operations are complete before resources are released.
-        if let Some(read) = s.read.as_ref() {
-            s.stream.ctx.record_err(s.stream.wait(read));
-        }
-        if let Some(write) = s.write.as_ref() {
-            s.stream.ctx.record_err(s.stream.wait(write));
+        if s.stream.ctx.is_managing_stream_synchronization() {
+            if let Some(read) = s.read.as_ref() {
+                s.stream.ctx.record_err(s.stream.wait(read));
+            }
+            if let Some(write) = s.write.as_ref() {
+                s.stream.ctx.record_err(s.stream.wait(write));
+            }
         }
 
         // Manually drop fields that own resources.

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -800,11 +800,13 @@ unsafe impl<T> Sync for CudaSlice<T> {}
 impl<T> Drop for CudaSlice<T> {
     fn drop(&mut self) {
         let ctx = &self.stream.ctx;
-        if let Some(read) = self.read.as_ref() {
-            ctx.record_err(self.stream.wait(read));
-        }
-        if let Some(write) = self.write.as_ref() {
-            ctx.record_err(self.stream.wait(write));
+        if ctx.is_managing_stream_synchronization() {
+            if let Some(read) = self.read.as_ref() {
+                ctx.record_err(self.stream.wait(read));
+            }
+            if let Some(write) = self.write.as_ref() {
+                ctx.record_err(self.stream.wait(write));
+            }
         }
         if ctx.has_async_alloc {
             ctx.record_err(unsafe {
@@ -1132,7 +1134,9 @@ impl Drop for SyncOnDrop<'_> {
         match self {
             SyncOnDrop::Record(target) => {
                 if let Some((event, stream)) = std::mem::take(target) {
-                    stream.ctx.record_err(event.record(stream));
+                    if stream.ctx.is_managing_stream_synchronization() {
+                        stream.ctx.record_err(event.record(stream));
+                    }
                 }
             }
             SyncOnDrop::Sync(target) => {


### PR DESCRIPTION
## Summary
Fixes #590. There was an asymmetry between how cudarc enters vs. tears down
stream synchronization: entry points like `DevicePtr::device_ptr()` check
`is_managing_stream_synchronization()` before touching events, but the
corresponding teardown paths did not:

- `Drop for SyncOnDrop::Record` unconditionally called `event.record(stream)`.
- `Drop for CudaSlice` unconditionally called `stream.wait(event)` for its
  `read`/`write` events.

When a long-lived buffer was accessed during CUDA graph capture and then
dropped after the graph was destroyed, the associated event became invalid.
Teardown still tried to use it, producing a `CUDA_ERROR_INVALID_VALUE` that
got cached in `error_state` and resurfaced later on an unrelated call,
making it very hard to debug.

## Change
In `src/driver/safe/core.rs`:
- `SyncOnDrop::Record`'s `Drop` impl now skips `event.record(stream)` when
  `is_managing_stream_synchronization()` is false.
- `CudaSlice`'s `Drop` impl now skips both `stream.wait(read)` and
  `stream.wait(write)` when `is_managing_stream_synchronization()` is false.

`SyncOnDrop::Sync` is untouched since it's unrelated to multi-stream event
tracking.

## Test plan
- `cargo check --no-default-features --features driver,cuda-12080,dynamic-loading`
- `cargo test --no-default-features --features driver,cuda-12080,dynamic-loading --lib --no-run`
- No GPU available in this environment, so CUDA graph capture/drop wasn't
  exercised at runtime — would be good to confirm against the repro in #590
  on real hardware before merging.