### PR TITLE
feat(driver): expose the raw CUfunction handle

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -2280,6 +2280,14 @@ impl CudaModule {
 }
 
 impl CudaFunction {
+    /// Returns the raw CUDA Driver function handle.
+    ///
+    /// The returned handle remains valid only while this function and its
+    /// owning module remain alive.
+    pub fn cu_function(&self) -> sys::CUfunction {
+        self.cu_function
+    }
+
     pub fn occupancy_available_dynamic_smem_per_block(
         &self,
         num_blocks: u32,


### PR DESCRIPTION
`CudaFunction` wraps `sys::CUfunction` but offers no way to recover the raw handle. Tooling that builds explicit CUDA graphs — populating kernel nodes through `cuGraphAddKernelNode`, or launching through `cuLaunchKernelEx` with graph-specific attributes — needs the driver handle rather than the safe wrapper.

This adds a trivial accessor documenting that the handle stays valid only while the function and its owning module are alive.
