### PR TITLE
feat(driver): add capture-scoped CUDA graph memory pool

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -1,5 +1,6 @@
 use crate::driver::{
     result::{self, DriverError},
+    safe::graph_memory::{route_allocation, CudaGraphMemoryPoolInner},
     sys::{self, CUfunc_cache_enum, CUfunction_attribute_enum},
 };
 
@@ -791,6 +792,8 @@ pub struct CudaSlice<T> {
     pub(crate) read: Option<CudaEvent>,
     pub(crate) write: Option<CudaEvent>,
     pub(crate) stream: Arc<CudaStream>,
+    pub(crate) graph_memory: Option<Arc<CudaGraphMemoryPoolInner>>,
+    pub(crate) external_owner: Option<Arc<dyn std::fmt::Debug + Send + Sync>>,
     pub(crate) marker: PhantomData<*const T>,
 }
 
@@ -799,6 +802,9 @@ unsafe impl<T> Sync for CudaSlice<T> {}
 
 impl<T> Drop for CudaSlice<T> {
     fn drop(&mut self) {
+        if self.graph_memory.is_some() || self.external_owner.is_some() {
+            return;
+        }
         let ctx = &self.stream.ctx;
         if ctx.is_managing_stream_synchronization() {
             if let Some(read) = self.read.as_ref() {
@@ -1534,17 +1540,22 @@ impl CudaStream {
     /// Allocates an empty [CudaSlice] with 0 length.
     pub fn null<T>(self: &Arc<Self>) -> Result<CudaSlice<T>, result::DriverError> {
         self.ctx.bind_to_thread()?;
-        let cu_device_ptr = if self.ctx.has_async_alloc {
-            unsafe { result::malloc_async(self.cu_stream, 0) }?
-        } else {
-            unsafe { result::malloc_sync(0) }?
-        };
+        let (cu_device_ptr, graph_memory) =
+            if let Some((pointer, graph_memory)) = route_allocation(self, 0)? {
+                (pointer, Some(graph_memory))
+            } else if self.ctx.has_async_alloc {
+                (unsafe { result::malloc_async(self.cu_stream, 0) }?, None)
+            } else {
+                (unsafe { result::malloc_sync(0) }?, None)
+            };
         Ok(CudaSlice {
             cu_device_ptr,
             len: 0,
             read: None,
             write: None,
             stream: self.clone(),
+            graph_memory,
+            external_owner: None,
             marker: PhantomData,
         })
     }
@@ -1557,11 +1568,17 @@ impl CudaStream {
         len: usize,
     ) -> Result<CudaSlice<T>, DriverError> {
         self.ctx.bind_to_thread()?;
-        let cu_device_ptr = if self.ctx.has_async_alloc {
-            result::malloc_async(self.cu_stream, len * std::mem::size_of::<T>())?
-        } else {
-            result::malloc_sync(len * std::mem::size_of::<T>())?
-        };
+        let bytes = len
+            .checked_mul(std::mem::size_of::<T>())
+            .ok_or(DriverError(sys::CUresult::CUDA_ERROR_OUT_OF_MEMORY))?;
+        let (cu_device_ptr, graph_memory) =
+            if let Some((pointer, graph_memory)) = route_allocation(self, bytes)? {
+                (pointer, Some(graph_memory))
+            } else if self.ctx.has_async_alloc {
+                (result::malloc_async(self.cu_stream, bytes)?, None)
+            } else {
+                (result::malloc_sync(bytes)?, None)
+            };
         let (read, write) = if self.ctx.is_event_tracking() {
             (
                 Some(self.ctx.new_event(None)?),
@@ -1576,6 +1593,8 @@ impl CudaStream {
             read,
             write,
             stream: self.clone(),
+            graph_memory,
+            external_owner: None,
             marker: PhantomData,
         })
     }
@@ -2488,6 +2507,10 @@ impl<T> CudaSlice<T> {
     /// Drops the underlying host_buf if there is one.
     pub fn leak(self) -> sys::CUdeviceptr {
         let mut s = std::mem::ManuallyDrop::new(self);
+        assert!(
+            s.graph_memory.is_none() && s.external_owner.is_none(),
+            "a CUDA slice backed by an external owner cannot transfer ownership of its device pointer"
+        );
         let ptr = s.cu_device_ptr;
 
         // Ensure pending operations are complete before resources are released.
@@ -2505,6 +2528,8 @@ impl<T> CudaSlice<T> {
             std::ptr::drop_in_place(&mut s.read);
             std::ptr::drop_in_place(&mut s.write);
             std::ptr::drop_in_place(&mut s.stream);
+            std::ptr::drop_in_place(&mut s.graph_memory);
+            std::ptr::drop_in_place(&mut s.external_owner);
         }
 
         ptr
@@ -2539,8 +2564,52 @@ impl CudaStream {
             read,
             write,
             stream: self.clone(),
+            graph_memory: None,
+            external_owner: None,
             marker: PhantomData,
         }
+    }
+
+    /// Creates a non-owning CUDA slice while retaining the object that owns
+    /// the device address. Dropping the slice releases the owner instead of
+    /// calling `cuMemFree` on the pointer.
+    ///
+    /// This is intended for allocations whose lifetime is governed outside
+    /// CUDA's ordinary allocation APIs, including VMM mappings and imported
+    /// IPC allocations.
+    ///
+    /// # Safety
+    /// - `cu_device_ptr` must belong to this stream's CUDA context.
+    /// - Before any operation accesses the slice, the range must be readable
+    ///   or writable as required for `len * size_of::<T>()` bytes.
+    /// - `owner` must keep that range reserved for the complete slice lifetime.
+    pub unsafe fn upgrade_external_device_ptr<T, Owner>(
+        self: &Arc<Self>,
+        cu_device_ptr: sys::CUdeviceptr,
+        len: usize,
+        owner: Arc<Owner>,
+    ) -> Result<CudaSlice<T>, DriverError>
+    where
+        Owner: std::fmt::Debug + Send + Sync + 'static,
+    {
+        let (read, write) = if self.ctx.is_event_tracking() {
+            (
+                Some(self.ctx.new_event(None)?),
+                Some(self.ctx.new_event(None)?),
+            )
+        } else {
+            (None, None)
+        };
+        Ok(CudaSlice {
+            cu_device_ptr,
+            len,
+            read,
+            write,
+            stream: self.clone(),
+            graph_memory: None,
+            external_owner: Some(owner),
+            marker: PhantomData,
+        })
     }
 }
 

--- a/src/driver/safe/graph_memory.rs
+++ b/src/driver/safe/graph_memory.rs
@@ -1,0 +1,317 @@
+use super::core::CudaStream;
+use crate::driver::{
+    result::{self, DriverError},
+    sys,
+};
+use std::sync::Arc;
+#[cfg(not(feature = "no-std"))]
+use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+
+const DEVICE_ALLOCATION_ALIGNMENT: usize = 256;
+
+#[derive(Debug)]
+pub(crate) struct CudaGraphMemoryPoolInner {
+    pointer: sys::CUdeviceptr,
+    capacity: usize,
+    stream: Arc<CudaStream>,
+}
+
+impl Drop for CudaGraphMemoryPoolInner {
+    fn drop(&mut self) {
+        let context = self.stream.context();
+        context.record_err(self.stream.synchronize());
+        if context.has_async_alloc {
+            context
+                .record_err(unsafe { result::free_async(self.pointer, self.stream.cu_stream()) });
+            context.record_err(self.stream.synchronize());
+        } else {
+            context.record_err(unsafe { result::free_sync(self.pointer) });
+        }
+    }
+}
+
+/// Rank- or device-local backing storage shared by CUDA graphs that are never
+/// replayed concurrently.
+///
+/// Each capture session uses a fresh bump cursor over the same storage. This
+/// deliberately keeps captured addresses stable without placing allocation or
+/// free nodes in the CUDA graph.
+#[derive(Clone, Debug)]
+pub struct CudaGraphMemoryPool {
+    inner: Arc<CudaGraphMemoryPoolInner>,
+}
+
+impl CudaGraphMemoryPool {
+    /// Allocates graph-private backing storage on `stream`.
+    pub fn new(stream: Arc<CudaStream>, capacity: usize) -> Result<Self, DriverError> {
+        let capacity = align_up(capacity).ok_or(out_of_memory())?;
+        if capacity == 0 {
+            return Err(invalid_value());
+        }
+        stream.context().bind_to_thread()?;
+        let pointer = if stream.context().has_async_alloc {
+            unsafe { result::malloc_async(stream.cu_stream(), capacity) }?
+        } else {
+            unsafe { result::malloc_sync(capacity) }?
+        };
+        let pool = Self {
+            inner: Arc::new(CudaGraphMemoryPoolInner {
+                pointer,
+                capacity,
+                stream,
+            }),
+        };
+        pool.inner.stream.synchronize()?;
+        Ok(pool)
+    }
+
+    /// Total reusable device storage in bytes.
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity
+    }
+
+    /// Routes allocations on this pool's stream into a fresh bump-allocation
+    /// session.
+    ///
+    /// Only available with threading support (not under `no-std`).
+    ///
+    /// # Safety
+    ///
+    /// Captures sharing a pool may retain aliased `CudaSlice` values. The
+    /// caller must ensure their executable graphs never overlap and that no
+    /// retained tensor is accessed outside its graph's serialized replay.
+    #[cfg(not(feature = "no-std"))]
+    pub unsafe fn begin_session(&self) -> Result<CudaGraphMemoryPoolSession, DriverError> {
+        GRAPH_MEMORY_MODE.with(|mode| {
+            let mut mode = mode.borrow_mut();
+            if mode.is_some() {
+                return Err(invalid_value());
+            }
+            *mode = Some(GraphMemoryMode::Pool {
+                stream: self.inner.stream.clone(),
+                pool: self.inner.clone(),
+                offset: 0,
+            });
+            Ok(CudaGraphMemoryPoolSession {
+                active: true,
+                not_send: PhantomData,
+            })
+        })
+    }
+}
+
+/// Measures the aligned storage needed by one allocation sequence while
+/// leaving its actual allocations unchanged.
+#[cfg(not(feature = "no-std"))]
+#[must_use]
+pub struct CudaGraphMemoryPoolProbe {
+    active: bool,
+    not_send: PhantomData<Rc<()>>,
+}
+
+#[cfg(not(feature = "no-std"))]
+impl CudaGraphMemoryPoolProbe {
+    /// Completes the probe and returns the required arena capacity.
+    pub fn finish(mut self) -> Result<usize, DriverError> {
+        let required = take_probe()?;
+        self.active = false;
+        Ok(required)
+    }
+}
+
+#[cfg(not(feature = "no-std"))]
+impl Drop for CudaGraphMemoryPoolProbe {
+    fn drop(&mut self) {
+        if self.active {
+            clear_mode();
+        }
+    }
+}
+
+/// Thread-local allocation routing active for a warmup or CUDA graph capture.
+#[cfg(not(feature = "no-std"))]
+#[must_use]
+pub struct CudaGraphMemoryPoolSession {
+    active: bool,
+    not_send: PhantomData<Rc<()>>,
+}
+
+#[cfg(not(feature = "no-std"))]
+impl CudaGraphMemoryPoolSession {
+    /// Completes the session and returns the bytes consumed by its bump cursor.
+    pub fn finish(mut self) -> Result<usize, DriverError> {
+        let used = take_pool_session()?;
+        self.active = false;
+        Ok(used)
+    }
+}
+
+#[cfg(not(feature = "no-std"))]
+impl Drop for CudaGraphMemoryPoolSession {
+    fn drop(&mut self) {
+        if self.active {
+            clear_mode();
+        }
+    }
+}
+
+impl CudaStream {
+    /// Begins measuring the storage required by allocations on this stream.
+    #[cfg(not(feature = "no-std"))]
+    pub fn probe_graph_memory_pool(
+        self: &Arc<Self>,
+    ) -> Result<CudaGraphMemoryPoolProbe, DriverError> {
+        GRAPH_MEMORY_MODE.with(|mode| {
+            let mut mode = mode.borrow_mut();
+            if mode.is_some() {
+                return Err(invalid_value());
+            }
+            *mode = Some(GraphMemoryMode::Probe {
+                stream: self.clone(),
+                required: 0,
+            });
+            Ok(CudaGraphMemoryPoolProbe {
+                active: true,
+                not_send: PhantomData,
+            })
+        })
+    }
+}
+
+#[cfg(not(feature = "no-std"))]
+enum GraphMemoryMode {
+    Probe {
+        stream: Arc<CudaStream>,
+        required: usize,
+    },
+    Pool {
+        stream: Arc<CudaStream>,
+        pool: Arc<CudaGraphMemoryPoolInner>,
+        offset: usize,
+    },
+}
+
+#[cfg(not(feature = "no-std"))]
+thread_local! {
+    static GRAPH_MEMORY_MODE: RefCell<Option<GraphMemoryMode>> = const { RefCell::new(None) };
+}
+
+#[cfg(not(feature = "no-std"))]
+pub(crate) fn route_allocation(
+    stream: &Arc<CudaStream>,
+    bytes: usize,
+) -> Result<Option<(sys::CUdeviceptr, Arc<CudaGraphMemoryPoolInner>)>, DriverError> {
+    let aligned = align_up(bytes).ok_or(out_of_memory())?;
+    GRAPH_MEMORY_MODE.with(|mode| {
+        let mut mode = mode.borrow_mut();
+        match mode.as_mut() {
+            None => Ok(None),
+            Some(GraphMemoryMode::Probe {
+                stream: active_stream,
+                required,
+            }) => {
+                ensure_stream(active_stream, stream)?;
+                *required = required.checked_add(aligned).ok_or(out_of_memory())?;
+                Ok(None)
+            }
+            Some(GraphMemoryMode::Pool {
+                stream: active_stream,
+                pool,
+                offset,
+            }) => {
+                ensure_stream(active_stream, stream)?;
+                let end = offset.checked_add(aligned).ok_or(out_of_memory())?;
+                if end > pool.capacity {
+                    return Err(out_of_memory());
+                }
+                let device_offset = u64::try_from(*offset).map_err(|_| out_of_memory())?;
+                let pointer = pool
+                    .pointer
+                    .checked_add(device_offset)
+                    .ok_or(out_of_memory())?;
+                *offset = end;
+                Ok(Some((pointer, pool.clone())))
+            }
+        }
+    })
+}
+
+#[cfg(feature = "no-std")]
+pub(crate) fn route_allocation(
+    _stream: &Arc<CudaStream>,
+    _bytes: usize,
+) -> Result<Option<(sys::CUdeviceptr, Arc<CudaGraphMemoryPoolInner>)>, DriverError> {
+    Ok(None)
+}
+
+fn align_up(bytes: usize) -> Option<usize> {
+    bytes
+        .checked_add(DEVICE_ALLOCATION_ALIGNMENT - 1)
+        .map(|value| value & !(DEVICE_ALLOCATION_ALIGNMENT - 1))
+}
+
+#[cfg(not(feature = "no-std"))]
+fn ensure_stream(expected: &Arc<CudaStream>, actual: &Arc<CudaStream>) -> Result<(), DriverError> {
+    if Arc::ptr_eq(expected, actual) {
+        Ok(())
+    } else {
+        Err(invalid_value())
+    }
+}
+
+#[cfg(not(feature = "no-std"))]
+fn take_probe() -> Result<usize, DriverError> {
+    GRAPH_MEMORY_MODE.with(|mode| {
+        let state = mode.borrow_mut().take();
+        match state {
+            Some(GraphMemoryMode::Probe { required, .. }) => Ok(required),
+            other => {
+                *mode.borrow_mut() = other;
+                Err(invalid_value())
+            }
+        }
+    })
+}
+
+#[cfg(not(feature = "no-std"))]
+fn take_pool_session() -> Result<usize, DriverError> {
+    GRAPH_MEMORY_MODE.with(|mode| {
+        let state = mode.borrow_mut().take();
+        match state {
+            Some(GraphMemoryMode::Pool { offset, .. }) => Ok(offset),
+            other => {
+                *mode.borrow_mut() = other;
+                Err(invalid_value())
+            }
+        }
+    })
+}
+
+#[cfg(not(feature = "no-std"))]
+fn clear_mode() {
+    GRAPH_MEMORY_MODE.with(|mode| {
+        mode.borrow_mut().take();
+    });
+}
+
+fn invalid_value() -> DriverError {
+    DriverError(sys::CUresult::CUDA_ERROR_INVALID_VALUE)
+}
+
+fn out_of_memory() -> DriverError {
+    DriverError(sys::CUresult::CUDA_ERROR_OUT_OF_MEMORY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::align_up;
+
+    #[test]
+    fn graph_pool_allocations_use_cuda_alignment() {
+        assert_eq!(align_up(0), Some(0));
+        assert_eq!(align_up(1), Some(256));
+        assert_eq!(align_up(256), Some(256));
+        assert_eq!(align_up(257), Some(512));
+        assert_eq!(align_up(usize::MAX), None);
+    }
+}

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod core;
 pub(crate) mod external_memory;
 pub(crate) mod graph;
+pub(crate) mod graph_memory;
 pub(crate) mod launch;
 pub(crate) mod profile;
 pub(crate) mod unified_memory;
@@ -14,6 +15,9 @@ pub use self::core::{
 };
 pub use self::external_memory::{ExternalMemory, MappedBuffer};
 pub use self::graph::CudaGraph;
+pub use self::graph_memory::CudaGraphMemoryPool;
+#[cfg(not(feature = "no-std"))]
+pub use self::graph_memory::{CudaGraphMemoryPoolProbe, CudaGraphMemoryPoolSession};
 pub use self::launch::{LaunchArgs, LaunchConfig, PushKernelArg};
 pub use self::profile::{profiler_start, profiler_stop, Profiler};
 pub use self::unified_memory::{UnifiedSlice, UnifiedView, UnifiedViewMut};


### PR DESCRIPTION
Related: #501, #536.

Allocations issued with `cuMemAllocAsync` while a stream is capturing become allocation/free *nodes inside the graph*, and their addresses are re-baked at every instantiation. Workloads that capture once per shape at startup and then replay thousands of times (e.g. inference decode loops) instead want all capture-time allocations to land in one preallocated arena at stable addresses, keeping graphs free of alloc/free nodes entirely.

This PR adds `CudaGraphMemoryPool`, a device-local arena shared by graphs that are never replayed concurrently:

- `CudaStream::probe_graph_memory_pool()` measures the aligned storage a warmup allocation sequence needs, without changing its behavior.
- `CudaGraphMemoryPool::new(stream, capacity)` allocates the arena.
- `unsafe begin_session()` starts a bump-allocation session: every `CudaStream::alloc`/`null` on that stream is routed into the arena at 256-byte alignment, and the resulting `CudaSlice`s are pool-owned (their `Drop` does not free). `CudaGraphMemoryPoolSession::finish()` reports the bytes consumed.

Session state is thread-local, so unrelated allocations in the same process are unaffected. The TLS-based session API is gated off under `no-std` (`no_std_compat` has no `thread_local!`); the pool type itself remains available there. Happy to restructure this (e.g. stream-owned session state) if you prefer.

`CudaSlice::leak()` now refuses to transfer ownership of pool-backed slices, since the arena — not the caller — owns those addresses.

Verified downstream: a DeepSeek V4 TP2 inference engine captures its 43-layer decode graph against one arena per rank, removing 105 alloc + 105 free nodes per rank.
