### PR TITLE
Add consuming ViewMut -> View conversion

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -942,7 +942,7 @@ impl<T> CudaSlice<T> {
     }
 }
 
-impl<T> CudaViewMut<'_, T> {
+impl<'a, T> CudaViewMut<'a, T> {
     /// Number of elements `T` that are in this view.
     pub fn len(&self) -> usize {
         self.len
@@ -953,6 +953,18 @@ impl<T> CudaViewMut<'_, T> {
 
     /// Downgrade this to a `&[T]`
     pub fn as_view<'b>(&'b self) -> CudaView<'b, T> {
+        CudaView {
+            ptr: self.ptr,
+            len: self.len,
+            read: self.read,
+            write: self.write,
+            stream: self.stream,
+            marker: PhantomData,
+        }
+    }
+
+    /// Downgrate this into to a `&[T]`, consuming the current view and keeping the original lifetime 'a
+    pub fn into_view(self) -> CudaView<'a, T> {
         CudaView {
             ptr: self.ptr,
             len: self.len,


### PR DESCRIPTION
I'd like to add a feature where we can have a `CudaViewMut` -> `CudaView` conversion that is consuming the ViewMut and thereby keeping its lifetime.


## Problem Statement

If the view would behave like a reference, you could convert a `&mut` into a `&` but you can't for `CudaViewMut` and `CudaView` or provide a general function that would do that.

For example: Imagine you have a trait or struct that can return a byte view to one of its buffers.

```rust
trait ByteViewable {
    fn buffer_view_mut(&mut self) -> Result<CudaViewMut<'_, u8>, Error>;

    fn buffer_view(&mut self, name: &str) -> Result<CudaView<'_, u8>, Error> {
        let view_mut = self.named_buffer_view(name)?
        let view = view_mut.as_view()
        view
        // <--- view_mut is dropped here so view can't be returned
    }
}
```

`buffer_view_mut()` and `buffer_view()` would need to be implemented separately as `CudaView` cannot be constructed from a `CudaViewMut` while keeping its lifetime - it would need to do everything from its original `CudaSlice`, duplicating the code needed and potential sources of errors.

## Proposal

Add a consuming alternative to `as_view()`, called `into_view()` that makes the additional implementation possible in spirit.

```rust
trait ByteViewable {
    fn buffer_view_mut(&mut self) -> Result<CudaViewMut<'_, u8>, Error>;

    fn buffer_view(&mut self, name: &str) -> Result<CudaView<'_, u8>, Error> {
        let view_mut = self.named_buffer_view(name)?
        let view = view_mut.into_view() // <--- consumes view_mut, keeping the original lifetime
        view
    }
}
```

### Alternatives

The only alternative that I could think of is  implement `Into<CudaView>` trait for `CudaViewMut`